### PR TITLE
president-setTax

### DIFF
--- a/internal/server/roles/base_president.go
+++ b/internal/server/roles/base_president.go
@@ -27,7 +27,7 @@ func (p *BasePresident) setTaxationAmount(islands_resources map[int]int) {
 }
 
 // Set allowed resource allocation based on each islands requests
-func (p *BasePresident) setAllocationRequest() {
+func (p *BasePresident) evaluateAllocationRequests() {
 	resourceAllocation := make(map[int]int)
 	for id, request := range p.resourceRequests {
 		resourceAllocation[id] = rand.Intn(request)
@@ -36,7 +36,7 @@ func (p *BasePresident) setAllocationRequest() {
 }
 
 // Chose a rule proposal from all the proposals
-func (p *BasePresident) choseRuleFromProposals() {
+func (p *BasePresident) pickRuleToVote() {
 	if len(p.rulesProposals) == 0 {
 		// No rules were proposed by the islands
 		p.ruleToVote = -1

--- a/internal/server/roles/base_president.go
+++ b/internal/server/roles/base_president.go
@@ -1,37 +1,64 @@
 package roles
 
-//base President Object
+import (
+	"math/rand"
+)
+
+//base President Objectlist
 type BasePresident struct {
 	id                 int
 	budget             int
 	speakerSalary      int
+	rulesProposals     []int
 	resourceRequests   map[int]int
 	resourceAllocation map[int]int
 	ruleToVote         int
-	taxAmount          int
+	taxAmountMap       map[int]int
 }
 
 // Set taxation amount for all of the living islands
-func (p *BasePresident) setTaxationAmount() {
-
+// island_resources: map of all the living islands and their remaing resources
+func (p *BasePresident) setTaxationAmount(islands_resources map[int]int) {
+	taxAmountMap := make(map[int]int)
+	for id, resource_left := range islands_resources {
+		taxAmountMap[id] = rand.Intn(resource_left)
+	}
+	p.taxAmountMap = taxAmountMap
 }
 
-// Obtain a rule proposal from each of the living islands
-func (p *BasePresident) getRuleProposals() {
-
+// Set allowed resource allocation based on each islands requests
+func (p *BasePresident) setAllocationRequest() {
+	resourceAllocation := make(map[int]int)
+	for id, request := range p.resourceRequests {
+		resourceAllocation[id] = rand.Intn(request)
+	}
+	p.resourceAllocation = resourceAllocation
 }
 
-// Broadcast tax amount to each of the living islands
-func (p *BasePresident) signalTaxationAmount() {
-
-}
-
-// Broadcast approved common pool resource request to each of the living islands
-func (p *BasePresident) signalAllocationRequest() {
-
+// Chose a rule proposal from all the proposals
+func (p *BasePresident) choseRuleFromProposals() {
+	if len(p.rulesProposals) == 0 {
+		// No rules were proposed by the islands
+		p.ruleToVote = -1
+	} else {
+		p.ruleToVote = rand.Intn(len(p.rulesProposals))
+	}
 }
 
 // Send rule to be voted on to Speaker
-func (p *BasePresident) sendRuleToSpeaker() {
+// Called by orchestration at the end of the turn
+func (p *BasePresident) GetRuleForSpeaker() int {
+	return p.ruleToVote
+}
 
+// Send Tax map all the remaining islands
+// Called by orchestration at the end of the turn
+func (p *BasePresident) GetTaxMap() map[int]int {
+	return p.taxAmountMap
+}
+
+// Send approved resources request for all the remaining islands
+// Called by orchestration at the end of the turn
+func (p *BasePresident) GetAllocationRequest() map[int]int {
+	return p.resourceAllocation
 }

--- a/internal/server/roles/base_president.go
+++ b/internal/server/roles/base_president.go
@@ -1,7 +1,7 @@
 package roles
 
 //base President Object
-type basePresident struct {
+type BasePresident struct {
 	id                 int
 	budget             int
 	speakerSalary      int
@@ -9,4 +9,29 @@ type basePresident struct {
 	resourceAllocation map[int]int
 	ruleToVote         int
 	taxAmount          int
+}
+
+// Set taxation amount for all of the living islands
+func (p *BasePresident) setTaxationAmount() {
+
+}
+
+// Obtain a rule proposal from each of the living islands
+func (p *BasePresident) getRuleProposals() {
+
+}
+
+// Broadcast tax amount to each of the living islands
+func (p *BasePresident) signalTaxationAmount() {
+
+}
+
+// Broadcast approved common pool resource request to each of the living islands
+func (p *BasePresident) signalAllocationRequest() {
+
+}
+
+// Send rule to be voted on to Speaker
+func (p *BasePresident) sendRuleToSpeaker() {
+
 }

--- a/internal/server/roles/base_president.go
+++ b/internal/server/roles/base_president.go
@@ -5,29 +5,19 @@ import (
 )
 
 //base President Objectlist
-type BasePresident struct {
+type basePresident struct {
 	id                 int
 	budget             int
 	speakerSalary      int
-	rulesProposals     []int
+	rulesProposals     []string
 	resourceRequests   map[int]int
 	resourceAllocation map[int]int
-	ruleToVote         int
+	ruleToVote         string
 	taxAmountMap       map[int]int
 }
 
-// Set taxation amount for all of the living islands
-// island_resources: map of all the living islands and their remaing resources
-func (p *BasePresident) setTaxationAmount(islands_resources map[int]int) {
-	taxAmountMap := make(map[int]int)
-	for id, resource_left := range islands_resources {
-		taxAmountMap[id] = rand.Intn(resource_left)
-	}
-	p.taxAmountMap = taxAmountMap
-}
-
 // Set allowed resource allocation based on each islands requests
-func (p *BasePresident) evaluateAllocationRequests() {
+func (p *basePresident) evaluateAllocationRequests() {
 	resourceAllocation := make(map[int]int)
 	for id, request := range p.resourceRequests {
 		resourceAllocation[id] = rand.Intn(request)
@@ -36,29 +26,53 @@ func (p *BasePresident) evaluateAllocationRequests() {
 }
 
 // Chose a rule proposal from all the proposals
-func (p *BasePresident) pickRuleToVote() {
+func (p *basePresident) pickRuleToVote() {
 	if len(p.rulesProposals) == 0 {
 		// No rules were proposed by the islands
-		p.ruleToVote = -1
+		p.ruleToVote = ""
 	} else {
-		p.ruleToVote = rand.Intn(len(p.rulesProposals))
+		p.ruleToVote = p.rulesProposals[rand.Intn(len(p.rulesProposals))]
 	}
 }
 
-// Send rule to be voted on to Speaker
+// Get rule proposals to be voted on from remaining islands
+// Called by orchestration
+func (p *basePresident) SetRuleProposals(rulesProposals []string) {
+	p.rulesProposals = rulesProposals
+	p.pickRuleToVote()
+}
+
+// Set approved resources request for all the remaining islands
+// Called by orchestration
+func (p *basePresident) SetAllocationRequest(resourceRequests map[int]int) {
+	p.resourceRequests = resourceRequests
+	p.evaluateAllocationRequests()
+}
+
+// Set taxation amount for all of the living islands
+// island_resources: map of all the living islands and their remaing resources
+func (p *basePresident) SetTaxationAmount(islands_resources map[int]int) {
+	taxAmountMap := make(map[int]int)
+	for id, resource_left := range islands_resources {
+		taxAmountMap[id] = rand.Intn(resource_left)
+	}
+	p.taxAmountMap = taxAmountMap
+}
+
+// Get rules to be voted on to Speaker
 // Called by orchestration at the end of the turn
-func (p *BasePresident) GetRuleForSpeaker() int {
+func (p *basePresident) GetRuleForSpeaker() string {
 	return p.ruleToVote
 }
 
 // Send Tax map all the remaining islands
 // Called by orchestration at the end of the turn
-func (p *BasePresident) GetTaxMap() map[int]int {
+func (p *basePresident) GetTaxMap() map[int]int {
 	return p.taxAmountMap
 }
 
 // Send approved resources request for all the remaining islands
 // Called by orchestration at the end of the turn
-func (p *BasePresident) GetAllocationRequest() map[int]int {
+func (p *basePresident) GetAllocationRequest() map[int]int {
 	return p.resourceAllocation
 }


### PR DESCRIPTION
# Summary

Added basic functions to the president and made some important changes regarding the president methods.

Due to implementation constraints of the messaging (+@Neelesh99 comments), the methods were restructured:

## Information Exchange
The following methods required to send or receive information to or from other party
* sendRuleToSpeaker
* replyAllocationRequest
*signalTaxation
* signalAllocationRequest
* requestRuleProposals

This has been renamed to get and set.
Instead, *get methods* have been created that return private variables with the chosen rule, allocation_map, and TaxMap respectively. Those *get_methods* will be called by the orchestration package AFTER the president role is played. 

## Additional Information

If we go ahead with this implementation, the design docs should be updated. 