### PR TITLE
Add TrustScore functionality

### DIFF
--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -24,9 +24,10 @@ type client struct {
 
 	// ## Trust ##
 
-	theirTrustScore map[shared.ClientID]float64
-	trustScore      map[shared.ClientID]float64
-	trustMapAgg     map[shared.ClientID][]float64
+	theirTrustScore  map[shared.ClientID]float64
+	trustScore       map[shared.ClientID]float64
+	trustMapAgg      map[shared.ClientID][]float64
+	theirTrustMapAgg map[shared.ClientID][]float64
 
 	// ## Role performance ##
 

--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -24,8 +24,9 @@ type client struct {
 
 	// ## Trust ##
 
-	theirTrustScore map[shared.ClientID]uint
-	trustScore      map[shared.ClientID]uint
+	theirTrustScore map[shared.ClientID]float64
+	trustScore      map[shared.ClientID]float64
+	trustMapAgg     map[shared.ClientID][]float64
 
 	// ## Role performance ##
 

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -53,9 +53,25 @@ func (c *client) updatetrustMapAgg(ClientID shared.ClientID, amount float64) {
 	c.trustMapAgg[ClientID] = append(c.trustMapAgg[ClientID], amount)
 }
 
+// updatetheirtrustMapAgg adds the amount to the their aggregate trust map list for given client
+func (c *client) updatetheirtrustMapAgg(ClientID shared.ClientID, amount float64) {
+	c.theirTrustMapAgg[ClientID] = append(c.theirTrustMapAgg[ClientID], amount)
+}
+
 // inittrustMapAgg initialises the trustMapAgg to empty list values ready for each turn
 func (c *client) inittrustMapAgg() {
 	c.trustMapAgg = map[shared.ClientID][]float64{
+		0: []float64{},
+		1: []float64{},
+		3: []float64{},
+		4: []float64{},
+		5: []float64{},
+	}
+}
+
+// inittheirtrustMapAgg initialises the theirTrustMapAgg to empty list values ready for each turn
+func (c *client) inittheirtrustMapAgg() {
+	c.theirTrustMapAgg = map[shared.ClientID][]float64{
 		0: []float64{},
 		1: []float64{},
 		3: []float64{},
@@ -80,6 +96,22 @@ func (c *client) updateTrustScore(trustMapAgg map[shared.ClientID][]float64) {
 	}
 }
 
+// updateTheirTrustScore obtains average of all accumulated trust changes
+// and updates the trustScore global map with new values
+// ensuring that the values do not drop below 0 or exceed 100
+func (c *client) updateTheirTrustScore(theirTrustMapAgg map[shared.ClientID][]float64) {
+	for client, val := range theirTrustMapAgg {
+		avgScore := getAverage(val)
+		if c.theirTrustScore[client]+avgScore > 100.0 {
+			avgScore = 100.0 - c.theirTrustScore[client]
+		}
+		if c.theirTrustScore[client]+avgScore < 0.0 {
+			avgScore = 0.0 - c.theirTrustScore[client]
+		}
+		c.theirTrustScore[client] += avgScore
+	}
+}
+
 /*
 	ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent)
 	GetCommunications() *map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
@@ -90,10 +122,6 @@ func (c *client) updateTrustScore(trustMapAgg map[shared.ClientID][]float64) {
 	getCompliance
 
 	updateCriticalThreshold
-
-	updateTrustScore
-	updateTheirTrustScore
-	decayTrust (may not be needed)
 
 	evalPresidentPerformance
 	evalSpeakerPerformance

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -48,6 +48,38 @@ func (c *client) Initialise(serverReadHandle baseclient.ServerReadHandle) {
 	// Initialise variables
 }
 
+// updatetrustMapAgg adds the amount to the aggregate trust map list for given client
+func (c *client) updatetrustMapAgg(ClientID shared.ClientID, amount float64) {
+	c.trustMapAgg[ClientID] = append(c.trustMapAgg[ClientID], amount)
+}
+
+// inittrustMapAgg initialises the trustMapAgg to empty list values ready for each turn
+func (c *client) inittrustMapAgg() {
+	c.trustMapAgg = map[shared.ClientID][]float64{
+		0: []float64{},
+		1: []float64{},
+		3: []float64{},
+		4: []float64{},
+		5: []float64{},
+	}
+}
+
+// updateTrustScore obtains average of all accumulated trust changes
+// and updates the trustScore global map with new values
+// ensuring that the values do not drop below 0 or exceed 100
+func (c *client) updateTrustScore(trustMapAgg map[shared.ClientID][]float64) {
+	for client, val := range trustMapAgg {
+		avgScore := getAverage(val)
+		if c.trustScore[client]+avgScore > 100.0 {
+			avgScore = 100.0 - c.trustScore[client]
+		}
+		if c.trustScore[client]+avgScore < 0.0 {
+			avgScore = 0.0 - c.trustScore[client]
+		}
+		c.trustScore[client] += avgScore
+	}
+}
+
 /*
 	ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent)
 	GetCommunications() *map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent

--- a/internal/clients/team3/clientgeneral_test.go
+++ b/internal/clients/team3/clientgeneral_test.go
@@ -1,0 +1,196 @@
+package team3
+
+// General client functions testing
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+)
+
+func TestUpdateTrustMapAgg(t *testing.T) {
+	cases := []struct {
+		name        string
+		ourClient   client
+		clientID    shared.ClientID
+		amount      float64
+		expectedVal map[shared.ClientID][]float64
+	}{
+		{
+			name: "Basic test",
+			ourClient: client{
+				trustMapAgg: map[shared.ClientID][]float64{
+					0: []float64{},
+					1: []float64{},
+					3: []float64{},
+					4: []float64{},
+					5: []float64{},
+				},
+			},
+			clientID: 1,
+			amount:   10.34,
+			expectedVal: map[shared.ClientID][]float64{
+				0: []float64{},
+				1: []float64{10.34},
+				3: []float64{},
+				4: []float64{},
+				5: []float64{},
+			},
+		},
+		{
+			name: "Basic Test 1",
+			ourClient: client{
+				trustMapAgg: map[shared.ClientID][]float64{
+					0: []float64{5.92},
+					1: []float64{62.78},
+					3: []float64{17.62},
+					4: []float64{-10.3},
+					5: []float64{6.42},
+				},
+			},
+			clientID: 4,
+			amount:   -9.56,
+			expectedVal: map[shared.ClientID][]float64{
+				0: []float64{5.92},
+				1: []float64{62.78},
+				3: []float64{17.62},
+				4: []float64{-10.3, -9.56},
+				5: []float64{6.42},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ourClient.updatetrustMapAgg(tc.clientID, tc.amount)
+			if !reflect.DeepEqual(tc.ourClient.trustMapAgg, tc.expectedVal) {
+				t.Errorf("Expected final transgressions to be %v got %v", tc.expectedVal, tc.ourClient.trustMapAgg)
+			}
+		})
+	}
+}
+
+func TestInitTrustMapAgg(t *testing.T) {
+	cases := []struct {
+		name        string
+		ourClient   client
+		expectedVal map[shared.ClientID][]float64
+	}{
+		{
+			name: "Basic test",
+			ourClient: client{
+				trustMapAgg: map[shared.ClientID][]float64{
+					0: []float64{5.92},
+					1: []float64{62.78},
+					3: []float64{17.62},
+					4: []float64{-10.3},
+					5: []float64{6.42},
+				},
+			},
+			expectedVal: map[shared.ClientID][]float64{
+				0: []float64{},
+				1: []float64{},
+				3: []float64{},
+				4: []float64{},
+				5: []float64{},
+			},
+		},
+		{
+			name: "Complex test",
+			ourClient: client{
+				trustMapAgg: map[shared.ClientID][]float64{
+					0: []float64{5.92, 8.97, 19.23},
+					1: []float64{62.78, 55.89, -10.65, -20.76},
+					3: []float64{17.62, 5.64, -15.67, 45.86, -99.80},
+					4: []float64{-10.3, 6.58, 3.74, -65.78, -78.98, 34.56},
+					5: []float64{6.42, 69.69, 98.87, -60.7857, 99.9999, 0.00001, 0.05},
+				},
+			},
+			expectedVal: map[shared.ClientID][]float64{
+				0: []float64{},
+				1: []float64{},
+				3: []float64{},
+				4: []float64{},
+				5: []float64{},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ourClient.inittrustMapAgg()
+			if !reflect.DeepEqual(tc.ourClient.trustMapAgg, tc.expectedVal) {
+				t.Errorf("Expected final transgressions to be %v got %v", tc.expectedVal, tc.ourClient.trustMapAgg)
+			}
+		})
+	}
+}
+
+func TestUpdateTrustScore(t *testing.T) {
+	cases := []struct {
+		name        string
+		ourClient   client
+		trustMapAgg map[shared.ClientID][]float64
+		expectedVal map[shared.ClientID]float64
+	}{
+		{
+			name: "Basic test",
+			ourClient: client{
+				trustScore: map[shared.ClientID]float64{
+					0: 50.0,
+					1: 50.0,
+					3: 50.0,
+					4: 50.0,
+					5: 50.0,
+				},
+			},
+			trustMapAgg: map[shared.ClientID][]float64{
+				0: []float64{5.92},
+				1: []float64{62.78},
+				3: []float64{17.62},
+				4: []float64{-50.3},
+				5: []float64{6.42},
+			},
+			expectedVal: map[shared.ClientID]float64{
+				0: 55.92,
+				1: 100,
+				3: 67.62,
+				4: 0,
+				5: 56.42,
+			},
+		},
+		{
+			name: "Complex test",
+			ourClient: client{
+				trustScore: map[shared.ClientID]float64{
+					0: 55.87,
+					1: 88.98,
+					3: 23.45,
+					4: 5.05,
+					5: 69.69,
+				},
+			},
+			trustMapAgg: map[shared.ClientID][]float64{
+				0: []float64{5.92, 8.97, 10.75},
+				1: []float64{12.78, -13.45, 23.45},
+				3: []float64{17.62, 25.62},
+				4: []float64{-86.56, 43.43, 48.99},
+				5: []float64{6.42, 0.001, -5.96, -45.45},
+			},
+			expectedVal: map[shared.ClientID]float64{
+				0: 64.41666666666666,
+				1: 96.57333333333334,
+				3: 45.07,
+				4: 7.003333333333333,
+				5: 58.44275,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ourClient.updateTrustScore(tc.trustMapAgg)
+			if !reflect.DeepEqual(tc.ourClient.trustScore, tc.expectedVal) {
+				t.Errorf("Expected final transgressions to be %v got %v", tc.expectedVal, tc.ourClient.trustScore)
+			}
+		})
+	}
+}

--- a/internal/clients/team3/clientiitoiifo.go
+++ b/internal/clients/team3/clientiitoiifo.go
@@ -21,6 +21,7 @@ package team3
 	UpdateGiftInfo(receivedResponses shared.GiftResponseDict)
 
 	//TODO: THESE ARE NOT DONE yet, how do people think we should implement the actual transfer?
+	// The server should handle the below functions maybe?
 	SentGift(sent shared.Resources, to shared.ClientID)
 	ReceivedGift(received shared.Resources, from shared.ClientID)
 

--- a/internal/clients/team3/utilfunctions.go
+++ b/internal/clients/team3/utilfunctions.go
@@ -19,8 +19,23 @@ func (c *client) getIslandsAlive() int {
 	lifeStatuses = currentState.ClientLifeStatuses
 	for _, statusInfo := range lifeStatuses {
 		if statusInfo == shared.Alive {
-			aliveCount += 1
+			aliveCount++
 		}
 	}
 	return aliveCount
+}
+
+// getAverage returns the average of the list
+func getAverage(lst []float64) float64 {
+
+	if len(lst) == 0 {
+		return 0.0
+	}
+
+	total := 0.0
+	for _, val := range lst {
+		total += val
+	}
+
+	return (float64(total) / float64(len(lst)))
 }


### PR DESCRIPTION
# Summary
This PR adds the implementation for the common trustScore functions.

## Additional Information
This change includes functionality for:
- inittrustMapAgg
- updatetrustMapAgg
- updateTrustScore

and the corresponding theirTrustScore functions as well.
Our client will essentially call updatetrustMapAgg, every time we want to make a change to the trust score with the relevant clientID of the island and the amount we want to change by, and the final trustScores for that turn will then be updated at the very end.

## Test Plan
We've added tests for testing all the major functions for updating trustScores in the clientgeneral_test.go file.
