### PR TITLE
Agent strategy - check if caught in the last turn

### DIFF
--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -62,6 +62,8 @@ type client struct {
 	params islandParams
 	// iigoInfo caches information regarding iigo in the current turn
 	iigoInfo iigoCommunicationInfo
+	// last sanction score cache to determine wheter or not we have been caugth in the last turn
+	last_sanctions roles.IIGOSanctionScore
 }
 
 type criticalStatePrediction struct {

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -44,6 +44,10 @@ func NewClient(clientID shared.ClientID) baseclient.Client {
 func (c *client) StartOfTurn() {
 	// c.Logf("Start of turn!")
 	// TODO add any functions and vairable changes here
+	var caught = c.checkIfCaught()
+	if caught {
+		c.timeSinceCaught = 0
+	}
 	c.updateCompliance()
 	c.resetIIGOInfo()
 }

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -155,6 +155,15 @@ func (c *client) shouldICheat() bool {
 	return should_i_cheat
 }
 
+// checkIfCaught, checks if the island has been caught during the last turn
+// If it has been caught, it returns True, otherwise False.
+func (c *client) checkIfCaught() bool {
+	if c.iigoInfo.sanctions.ourSanction > c.last_sanctions {
+		return true
+	}
+	return false
+}
+
 /*
 	DisasterNotification(disasters.DisasterReport, map[shared.ClientID]shared.Magnitude)
 	updateCompliance

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -44,8 +44,7 @@ func NewClient(clientID shared.ClientID) baseclient.Client {
 func (c *client) StartOfTurn() {
 	// c.Logf("Start of turn!")
 	// TODO add any functions and vairable changes here
-	var caught = c.checkIfCaught()
-	if caught {
+	if c.checkIfCaught() {
 		c.timeSinceCaught = 0
 	}
 	c.updateCompliance()
@@ -162,10 +161,7 @@ func (c *client) shouldICheat() bool {
 // checkIfCaught, checks if the island has been caught during the last turn
 // If it has been caught, it returns True, otherwise False.
 func (c *client) checkIfCaught() bool {
-	if c.iigoInfo.sanctions.ourSanction > c.last_sanctions {
-		return true
-	}
-	return false
+	return c.iigoInfo.sanctions.ourSanction > c.last_sanctions
 }
 
 /*

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -56,6 +56,7 @@ func (c *client) resetIIGOInfo() {
 	c.iigoInfo.ruleVotingResults = make(map[string]*ruleVoteInfo)
 	c.iigoInfo.ourRequest = 0
 	c.iigoInfo.ourDeclaredResources = 0
+	c.last_sanctions = 0
 }
 
 // ReceiveCommunication is a function called by IIGO to pass the communication sent to the client.


### PR DESCRIPTION
# Summary

Resets LastTimeSinceCaught every time we are caught

## Additional Information

I reset the variable based on the SanctionScore, if it has increased, I assume we have been caught in the previous turn. (@Neelesh99 I believe that is a correct assumption right?)

## Test Plan

- ran go test. No issue detected