### PR TITLE
Agent strategy iigocommunication

### DIFF
--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -58,6 +58,8 @@ type client struct {
 
 	// params is list of island wide function parameters
 	params islandParams
+
+	iigoInfo iigoCommunicationInfo
 }
 
 type islandParams struct {
@@ -76,4 +78,24 @@ type islandParams struct {
 	friendliness                float64
 	anger                       float64
 	aggression                  float64
+}
+
+type iigoCommunicationInfo struct {
+	// ourRole stores our current role in the IIGO
+	ourRole *shared.Role
+	// commonPoolAllocation gives resources allocated by president from requests
+	commonPoolAllocation shared.Resources
+	// taxationAmount gives tax amount decided by president
+	taxationAmount shared.Resources
+	// ruleVotingResults is a map of rules and the result of the vote for it
+	// true -> yes, false -> no
+	ruleVotingResults map[string]bool
+	// ruleVotingResultAnnounced stores whether a specific rule vote was announced
+	ruleVotingResultAnnounced map[string]bool
+	// monitoringOutcomes stores the outcome of the monitoring of an island.
+	// key is the role being monitored.
+	// true -> correct performance, false -> incorrect performance.
+	monitoringOutcomes map[shared.Role]bool
+	// monitoringDeclared stores as key the role being monitored and whether it was actually monitored.
+	monitoringDeclared map[shared.Role]bool
 }

--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -92,23 +92,36 @@ type sanctionInfo struct {
 	ourSanction roles.IIGOSanctionScore
 }
 
+type ruleVoteInfo struct {
+	// ourVote needs to be updated accordingly
+	ourVote         bool
+	resultAnnounced bool
+	// true -> yes, false -> no
+	result bool
+}
+
 type iigoCommunicationInfo struct {
+	// Retrieved fully from communications
+
 	// commonPoolAllocation gives resources allocated by president from requests
 	commonPoolAllocation shared.Resources
 	// taxationAmount gives tax amount decided by president
 	taxationAmount shared.Resources
-	// ruleVotingResults is a map of rules and the result of the vote for it
-	// true -> yes, false -> no
-	ruleVotingResults map[string]bool
-	// ruleVotingResultAnnounced stores whether a specific rule vote was announced
-	ruleVotingResultAnnounced map[string]bool
 	// monitoringOutcomes stores the outcome of the monitoring of an island.
 	// key is the role being monitored.
 	// true -> correct performance, false -> incorrect performance.
 	monitoringOutcomes map[shared.Role]bool
 	// monitoringDeclared stores as key the role being monitored and whether it was actually monitored.
 	monitoringDeclared map[shared.Role]bool
-
 	// Struct containing sanction information
 	sanctions sanctionInfo
+
+	// Below need to be at least partially updated by our functions
+
+	// ruleVotingResults is a map of rules and the corresponding info
+	ruleVotingResults map[string]*ruleVoteInfo
+	// ourRequest stores how much we requested from commonpool
+	ourRequest shared.Resources
+	// ourDeclaredResources stores how much we said we had to the president
+	ourDeclaredResources shared.Resources
 }

--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -17,6 +17,10 @@ func init() {
 
 type client struct {
 	*baseclient.BaseClient
+	ourSpeaker   speaker
+	ourJudge     judge
+	ourPresident president
+
 	// ## Gifting ##
 
 	acceptedGifts        map[shared.ClientID]int
@@ -114,7 +118,7 @@ type iigoCommunicationInfo struct {
 	// monitoringDeclared stores as key the role being monitored and whether it was actually monitored.
 	monitoringDeclared map[shared.Role]bool
 	// Struct containing sanction information
-	sanctions sanctionInfo
+	sanctions *sanctionInfo
 
 	// Below need to be at least partially updated by our functions
 

--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -58,6 +58,8 @@ type client struct {
 
 	// params is list of island wide function parameters
 	params islandParams
+
+	iigoInfo iigoCommunicationInfo
 }
 
 type islandParams struct {
@@ -76,4 +78,26 @@ type islandParams struct {
 	friendliness                float64
 	anger                       float64
 	aggression                  float64
+}
+
+type iigoCommunicationInfo struct {
+	// ourRole stores our current role in the IIGO
+	ourRole *shared.Role
+	// commonPoolAllocation gives resources allocated by president from requests
+	commonPoolAllocation shared.Resources
+	// taxationAmount gives tax amount decided by president
+	taxationAmount shared.Resources
+	// ruleVotingResults is a map of rules and the result of the vote for it
+	// true -> yes, false -> no
+	ruleVotingResults map[string]bool
+	// ruleVotingResultAnnounced stores whether a specific rule vote was announced
+	ruleVotingResultAnnounced map[string]bool
+	// monitoringOutcomes stores the outcome of the monitoring of an island.
+	// key is the role being monitored.
+	// true -> correct performance, false -> incorrect performance.
+	monitoringOutcomes map[shared.Role]bool
+	// monitoringDeclared stores as key the role being monitored and whether it was actually monitored.
+	monitoringDeclared map[shared.Role]bool
+
+	//TODO add sanctions and pardons
 }

--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -93,8 +93,6 @@ type sanctionInfo struct {
 }
 
 type iigoCommunicationInfo struct {
-	// ourRole stores our current role in the IIGO
-	ourRole *shared.Role
 	// commonPoolAllocation gives resources allocated by president from requests
 	commonPoolAllocation shared.Resources
 	// taxationAmount gives tax amount decided by president

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -41,6 +41,7 @@ func NewClient(clientID shared.ClientID) baseclient.Client {
 func (c *client) StartOfTurn() {
 	// c.Logf("Start of turn!")
 	// TODO add any functions and vairable changes here
+	c.resetIIGOInfo()
 }
 
 func (c *client) Initialise(serverReadHandle baseclient.ServerReadHandle) {
@@ -113,8 +114,6 @@ func (c *client) updateTheirTrustScore(theirTrustMapAgg map[shared.ClientID][]fl
 }
 
 /*
-	ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent)
-	GetCommunications() *map[shared.ClientID][]map[shared.CommunicationFieldName]shared.CommunicationContent
 	DisasterNotification(disasters.DisasterReport, map[shared.ClientID]shared.Magnitude)
 
 	updateCompliance

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -46,6 +46,9 @@ func (c *client) StartOfTurn() {
 
 func (c *client) Initialise(serverReadHandle baseclient.ServerReadHandle) {
 	c.ServerReadHandle = serverReadHandle
+	c.ourSpeaker = speaker{c: c}
+	c.ourJudge = judge{c: c}
+	c.ourPresident = president{c: c}
 	// Initialise variables
 }
 

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -28,33 +28,41 @@ import (
 
 func (c *client) GetClientSpeakerPointer() roles.Speaker {
 	// c.Logf("became speaker")
-	return &speaker{c: c}
+	return &c.ourSpeaker
 }
 
 func (c *client) GetClientJudgePointer() roles.Judge {
 	// c.Logf("became judge")
-	return &judge{c: c}
+	return &c.ourJudge
 }
 
 func (c *client) GetClientPresidentPointer() roles.President {
 	// c.Logf("became president")
-	return &president{c: c}
+	return &c.ourPresident
 }
 
 //resetIIGOInfo clears the island's information regarding IIGO at start of turn
 func (c *client) resetIIGOInfo() {
 	c.iigoInfo.commonPoolAllocation = 0
 	c.iigoInfo.taxationAmount = 0
-	c.iigoInfo.ruleVotingResults = make(map[string]*ruleVoteInfo)
 	c.iigoInfo.monitoringOutcomes = make(map[shared.Role]bool)
 	c.iigoInfo.monitoringDeclared = make(map[shared.Role]bool)
+	c.iigoInfo.sanctions = &sanctionInfo{
+		tierInfo:        make(map[roles.IIGOSanctionTier]roles.IIGOSanctionScore),
+		rulePenalties:   make(map[string]roles.IIGOSanctionScore),
+		islandSanctions: make(map[shared.ClientID]roles.IIGOSanctionTier),
+		ourSanction:     roles.IIGOSanctionScore(0),
+	}
+	c.iigoInfo.ruleVotingResults = make(map[string]*ruleVoteInfo)
+	c.iigoInfo.ourRequest = 0
+	c.iigoInfo.ourDeclaredResources = 0
 }
 
 // ReceiveCommunication is a function called by IIGO to pass the communication sent to the client.
 // This function is overridden to receive information and update local info accordingly.
 func (c *client) ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent) {
 	c.Communications[sender] = append(c.Communications[sender], data)
-
+	// TODO parse sanction info
 	for contentType, content := range data {
 		switch contentType {
 		case shared.TaxAmount:

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -4,7 +4,7 @@ import (
 	// "github.com/SOMAS2020/SOMAS2020/internal/common/baseclient"
 	"github.com/SOMAS2020/SOMAS2020/internal/common/roles"
 	// "github.com/SOMAS2020/SOMAS2020/internal/common/rules"
-	// "github.com/SOMAS2020/SOMAS2020/internal/common/shared"
+	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 )
 
 /*
@@ -28,15 +28,54 @@ import (
 
 func (c *client) GetClientSpeakerPointer() roles.Speaker {
 	// c.Logf("became speaker")
+	role := shared.Speaker
+	c.iigoInfo.ourRole = &role
 	return &speaker{c: c}
 }
 
 func (c *client) GetClientJudgePointer() roles.Judge {
 	// c.Logf("became judge")
+	role := shared.Judge
+	c.iigoInfo.ourRole = &role
 	return &judge{c: c}
 }
 
 func (c *client) GetClientPresidentPointer() roles.President {
 	// c.Logf("became president")
+	role := shared.President
+	c.iigoInfo.ourRole = &role
 	return &president{c: c}
+}
+
+//resetIIGOInfo clears the island's information regarding IIGO at start of turn
+func (c *client) resetIIGOInfo() {
+	c.iigoInfo.ourRole = nil
+	c.iigoInfo.commonPoolAllocation = 0
+	c.iigoInfo.taxationAmount = 0
+	c.iigoInfo.ruleVotingResults = make(map[string]bool)
+	c.iigoInfo.ruleVotingResultAnnounced = make(map[string]bool)
+	c.iigoInfo.monitoringOutcomes = make(map[shared.Role]bool)
+	c.iigoInfo.monitoringDeclared = make(map[shared.Role]bool)
+}
+
+// ReceiveCommunication is a function called by IIGO to pass the communication sent to the client.
+// This function is overridden to receive information and update local info accordingly.
+func (c *client) ReceiveCommunication(sender shared.ClientID, data map[shared.CommunicationFieldName]shared.CommunicationContent) {
+	c.Communications[sender] = append(c.Communications[sender], data)
+
+	for contentType, content := range data {
+		switch contentType {
+		case shared.TaxAmount:
+			c.iigoInfo.taxationAmount = shared.Resources(content.IntegerData)
+		case shared.AllocationAmount:
+			c.iigoInfo.commonPoolAllocation = shared.Resources(content.IntegerData)
+		case shared.RuleName:
+			currentRuleID := content.TextData
+			c.iigoInfo.ruleVotingResultAnnounced[currentRuleID] = true
+			c.iigoInfo.ruleVotingResults[currentRuleID] = data[shared.RuleVoteResult].BooleanData
+		case shared.RoleMonitored:
+			c.iigoInfo.monitoringDeclared[content.IIGORole] = true
+			c.iigoInfo.monitoringOutcomes[content.IIGORole] = data[shared.MonitoringResult].BooleanData
+		}
+	}
 }

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -28,28 +28,21 @@ import (
 
 func (c *client) GetClientSpeakerPointer() roles.Speaker {
 	// c.Logf("became speaker")
-	role := shared.Speaker
-	c.iigoInfo.ourRole = &role
 	return &speaker{c: c}
 }
 
 func (c *client) GetClientJudgePointer() roles.Judge {
 	// c.Logf("became judge")
-	role := shared.Judge
-	c.iigoInfo.ourRole = &role
 	return &judge{c: c}
 }
 
 func (c *client) GetClientPresidentPointer() roles.President {
 	// c.Logf("became president")
-	role := shared.President
-	c.iigoInfo.ourRole = &role
 	return &president{c: c}
 }
 
 //resetIIGOInfo clears the island's information regarding IIGO at start of turn
 func (c *client) resetIIGOInfo() {
-	c.iigoInfo.ourRole = nil
 	c.iigoInfo.commonPoolAllocation = 0
 	c.iigoInfo.taxationAmount = 0
 	c.iigoInfo.ruleVotingResults = make(map[string]bool)

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -45,8 +45,7 @@ func (c *client) GetClientPresidentPointer() roles.President {
 func (c *client) resetIIGOInfo() {
 	c.iigoInfo.commonPoolAllocation = 0
 	c.iigoInfo.taxationAmount = 0
-	c.iigoInfo.ruleVotingResults = make(map[string]bool)
-	c.iigoInfo.ruleVotingResultAnnounced = make(map[string]bool)
+	c.iigoInfo.ruleVotingResults = make(map[string]*ruleVoteInfo)
 	c.iigoInfo.monitoringOutcomes = make(map[shared.Role]bool)
 	c.iigoInfo.monitoringDeclared = make(map[shared.Role]bool)
 }
@@ -64,8 +63,12 @@ func (c *client) ReceiveCommunication(sender shared.ClientID, data map[shared.Co
 			c.iigoInfo.commonPoolAllocation = shared.Resources(content.IntegerData)
 		case shared.RuleName:
 			currentRuleID := content.TextData
-			c.iigoInfo.ruleVotingResultAnnounced[currentRuleID] = true
-			c.iigoInfo.ruleVotingResults[currentRuleID] = data[shared.RuleVoteResult].BooleanData
+			if _, ok := c.iigoInfo.ruleVotingResults[currentRuleID]; ok {
+				c.iigoInfo.ruleVotingResults[currentRuleID].resultAnnounced = true
+				c.iigoInfo.ruleVotingResults[currentRuleID].result = data[shared.RuleVoteResult].BooleanData
+			} else {
+				c.iigoInfo.ruleVotingResults[currentRuleID] = &ruleVoteInfo{resultAnnounced: true, result: data[shared.RuleVoteResult].BooleanData}
+			}
 		case shared.RoleMonitored:
 			c.iigoInfo.monitoringDeclared[content.IIGORole] = true
 			c.iigoInfo.monitoringOutcomes[content.IIGORole] = data[shared.MonitoringResult].BooleanData


### PR DESCRIPTION
# Summary

- Made role variables persistent though game, in case variables are used across turns.
- Added rests for iigo communication cache struct

## Additional Information

Need to add caching of previous sanction amount

## Test Plan

- Tested via logf inspection for roles.
