### PR TITLE
Added print function and flag, changed existing to use new function

### DIFF
--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -8,6 +8,7 @@ import (
 )
 
 const id = shared.Team3
+const printTeam3Logs = false
 
 func init() {
 	ourClient := &client{BaseClient: baseclient.NewClient(id),

--- a/internal/clients/team3/clientgeneral.go
+++ b/internal/clients/team3/clientgeneral.go
@@ -42,7 +42,7 @@ func NewClient(clientID shared.ClientID) baseclient.Client {
 }
 
 func (c *client) StartOfTurn() {
-	// c.Logf("Start of turn!")
+	c.clientPrint("Start of turn!")
 	// TODO add any functions and vairable changes here
 	c.updateCompliance()
 	c.resetIIGOInfo()

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -27,17 +27,17 @@ import (
 */
 
 func (c *client) GetClientSpeakerPointer() roles.Speaker {
-	// c.Logf("became speaker")
+	c.clientPrint("became speaker")
 	return &c.ourSpeaker
 }
 
 func (c *client) GetClientJudgePointer() roles.Judge {
-	// c.Logf("became judge")
+	c.clientPrint("became judge")
 	return &c.ourJudge
 }
 
 func (c *client) GetClientPresidentPointer() roles.President {
-	// c.Logf("became president")
+	c.clientPrint("became president")
 	return &c.ourPresident
 }
 

--- a/internal/clients/team3/president.go
+++ b/internal/clients/team3/president.go
@@ -18,7 +18,7 @@ func (p *president) PaySpeaker(salary shared.Resources) (shared.Resources, bool)
 }
 
 func (p *president) DecideNextSpeaker(winner shared.ClientID) shared.ClientID {
-	// p.c.Logf("choosing speaker")
+	p.c.clientPrint("choosing speaker")
 	// Naively choose group 0
 	return shared.ClientID(0)
 }

--- a/internal/clients/team3/utilfunctions.go
+++ b/internal/clients/team3/utilfunctions.go
@@ -1,8 +1,16 @@
 package team3
 
 import (
+	"fmt"
+
 	"github.com/SOMAS2020/SOMAS2020/internal/common/shared"
 )
+
+func (c *client) clientPrint(format string, a ...interface{}) {
+	if printTeam3Logs {
+		c.Logf("%v", fmt.Sprintf(format, a...))
+	}
+}
 
 // getLocalResources retrieves our islands resrouces from server
 func (c *client) getLocalResources() shared.Resources {


### PR DESCRIPTION
# Summary

Added `clientPrint` function, our version of `Logf` that has a guard, so we can choose to show or hide prints based on the `printTeam3Logs` flag. 

## Additional Information

Anything printed by our client has `[Team3]` prefixed, so use grep or ctrl+f to find prints
