### PR TITLE
init and update the criticalstateprediciton

### DIFF
--- a/internal/clients/team3/clientgeneral_test.go
+++ b/internal/clients/team3/clientgeneral_test.go
@@ -200,7 +200,7 @@ func TestUpdateCriticalThreshold(t *testing.T) {
 	cases := []struct {
 		name              string
 		ourClient         client
-		isInCriticalState bool
+		islandState       shared.ClientLifeStatus
 		estimatedResource shared.Resources
 		expected          criticalStatePrediction
 	}{
@@ -208,7 +208,7 @@ func TestUpdateCriticalThreshold(t *testing.T) {
 			name: "in Critical Test",
 			ourClient: client{
 				criticalStatePrediction: criticalStatePrediction{upperBound: 70, lowerBound: 30}},
-			isInCriticalState: true,
+			islandState:       shared.Critical,
 			estimatedResource: shared.Resources(40),
 			expected:          criticalStatePrediction{upperBound: 70, lowerBound: 40},
 		},
@@ -216,7 +216,7 @@ func TestUpdateCriticalThreshold(t *testing.T) {
 			name: "Not in Critical Test",
 			ourClient: client{
 				criticalStatePrediction: criticalStatePrediction{upperBound: 70, lowerBound: 30}},
-			isInCriticalState: false,
+			islandState:       shared.Alive,
 			estimatedResource: shared.Resources(60),
 			expected:          criticalStatePrediction{upperBound: 60, lowerBound: 30},
 		},
@@ -224,7 +224,7 @@ func TestUpdateCriticalThreshold(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.ourClient.updateCriticalThreshold(tc.isInCriticalState, tc.estimatedResource)
+			tc.ourClient.updateCriticalThreshold(tc.islandState, tc.estimatedResource)
 			ans := tc.ourClient.criticalStatePrediction
 			if ans != tc.expected {
 				t.Errorf("got %f-%f, want %f-%f", ans.lowerBound, ans.upperBound, tc.expected.lowerBound, tc.expected.upperBound)

--- a/internal/clients/team3/president.go
+++ b/internal/clients/team3/president.go
@@ -151,7 +151,10 @@ func (p *president) SetTaxationAmount(islandsResources map[shared.ClientID]share
 		adjustedResource := resource * shared.Resources(math.Pow(p.c.params.resourcesSkew, (100-p.c.trustScore[island])/100))
 		adjustedResources = append(adjustedResources, float64(adjustedResource))
 		adjustedResourcesMap[island] = adjustedResource
+		//update criticalThreshold
+		p.c.updateCriticalThreshold(p.c.ServerReadHandle.GetGameState().ClientLifeStatuses[island], shared.Resources(adjustedResource))
 	}
+
 	AveAdjustedResources := getAverage(adjustedResources)
 	taxationMap := make(map[shared.ClientID]shared.Resources)
 	for island, resources := range adjustedResourcesMap {


### PR DESCRIPTION
# Summary

Initialised the Critical State Prediction and update it every turn and when we are president

## Additional Information

Auxiliary information goes here.

## Test Plan

- Add information on how you tested your changes.
