### PR TITLE
Agent strategy shift

### DIFF
--- a/internal/clients/team3/client.go
+++ b/internal/clients/team3/client.go
@@ -74,6 +74,9 @@ type client struct {
 	// iigoInfo caches information regarding iigo in the current turn
 	iigoInfo iigoCommunicationInfo
 
+	// Last broken rules
+	oldBrokenRules []string
+
 	localVariableCache map[rules.VariableFieldName]rules.VariableValuePair
 
 	localInputsCache map[rules.VariableFieldName]dynamics.Input
@@ -109,6 +112,7 @@ type islandParams struct {
 	trustParameter              float64
 	NoRequestGiftParam          float64
 	laziness                    float64
+	intelligence                bool
 	//minimumInvestment			float64	// When fish foraging is implemented
 }
 

--- a/internal/clients/team3/clientconfig.go
+++ b/internal/clients/team3/clientconfig.go
@@ -20,5 +20,6 @@ func getislandParams() islandParams {
 		trustConstantAdjustor:       1,    // arbitrary
 		trustParameter:              0.5,  // 0-1
 		NoRequestGiftParam:          0.25, // 0-1
+		intelligence:                true,
 	}
 }

--- a/internal/clients/team3/clientiigo.go
+++ b/internal/clients/team3/clientiigo.go
@@ -42,6 +42,19 @@ func (c *client) GetClientPresidentPointer() roles.President {
 	return &c.ourPresident
 }
 
+func (c *client) VoteForElection(roleToElect shared.Role, candidateList []shared.ClientID) []shared.ClientID {
+	candidates := map[int]shared.ClientID{}
+	for i := 0; i < len(candidateList); i++ {
+		candidates[i] = candidateList[i]
+	}
+	// Recombine map, in shuffled order
+	var returnList []shared.ClientID
+	for _, v := range candidates {
+		returnList = append(returnList, v)
+	}
+	return returnList
+}
+
 //resetIIGOInfo clears the island's information regarding IIGO at start of turn
 func (c *client) resetIIGOInfo() {
 	c.iigoInfo.ourRole = nil // TODO unused, remove
@@ -114,7 +127,7 @@ func (c *client) GetTaxContribution() shared.Resources {
 		},
 	}
 	recommendedValues := c.dynamicAssistedResult(variablesChanged)
-	resolve := shared.Resources(recommendedValues[rules.IslandAllocation].Values[rules.SingleValueVariableEntry])
+	resolve := shared.Resources(recommendedValues[rules.IslandTaxContribution].Values[rules.SingleValueVariableEntry])
 	if c.params.complianceLevel > 80 {
 		return resolve
 	}

--- a/internal/clients/team3/dynamics/ruleanalysis.go
+++ b/internal/clients/team3/dynamics/ruleanalysis.go
@@ -126,7 +126,7 @@ func translateDynamic(inputDyn dynamic) []float64 {
 	nRows, _ := w.Dims()
 	outputVect := []float64{}
 	for i := 0; i < nRows; i++ {
-		outputVect = append(outputVect)
+		outputVect = append(outputVect, w.AtVec(i))
 	}
 	outputVect = append(outputVect, inputDyn.b)
 	return outputVect

--- a/internal/clients/team3/dynamics/ruleanalysis_test.go
+++ b/internal/clients/team3/dynamics/ruleanalysis_test.go
@@ -639,6 +639,110 @@ func TestFindClosestApproachInSubspace(t *testing.T) {
 	}
 }
 
+func TestShift(t *testing.T) {
+	_, medMap, _ := generateInputMaps()
+	cases := []struct {
+		name        string
+		inputMatrix rules.RuleMatrix
+		inputMap    map[rules.VariableFieldName]Input
+		edited      bool
+		outputMat   rules.RuleMatrix
+	}{
+		{
+			name: "Basic non edit test",
+			inputMatrix: rules.RuleMatrix{
+				RuleName: "Basic rule",
+				RequiredVariables: []rules.VariableFieldName{
+					rules.NumberOfBallotsCast,
+					rules.NumberOfIslandsAlive,
+				},
+				ApplicableMatrix: *mat.NewDense(2, 3, []float64{1, 1, 1, 1, 1, 1}),
+				AuxiliaryVector:  *mat.NewVecDense(2, []float64{1, 1}),
+				Mutable:          false,
+				Link:             rules.RuleLink{},
+			},
+			inputMap: medMap,
+			outputMat: rules.RuleMatrix{
+				RuleName: "Basic rule",
+				RequiredVariables: []rules.VariableFieldName{
+					rules.NumberOfBallotsCast,
+					rules.NumberOfIslandsAlive,
+				},
+				ApplicableMatrix: *mat.NewDense(2, 3, []float64{1, 1, 1, 1, 1, 1}),
+				AuxiliaryVector:  *mat.NewVecDense(2, []float64{1, 1}),
+				Mutable:          false,
+				Link:             rules.RuleLink{},
+			},
+			edited: false,
+		},
+		{
+			name: "Basic edit test",
+			inputMatrix: rules.RuleMatrix{
+				RuleName: "Basic rule",
+				RequiredVariables: []rules.VariableFieldName{
+					rules.NumberOfBallotsCast,
+					rules.NumberOfIslandsAlive,
+				},
+				ApplicableMatrix: *mat.NewDense(2, 3, []float64{1, 1, 1, 1, 1, 1}),
+				AuxiliaryVector:  *mat.NewVecDense(2, []float64{0, 1}),
+				Mutable:          false,
+				Link:             rules.RuleLink{},
+			},
+			inputMap: medMap,
+			outputMat: rules.RuleMatrix{
+				RuleName: "Basic rule",
+				RequiredVariables: []rules.VariableFieldName{
+					rules.NumberOfBallotsCast,
+					rules.NumberOfIslandsAlive,
+				},
+				ApplicableMatrix: *mat.NewDense(2, 3, []float64{1, 1, -12, 1, 1, 1}),
+				AuxiliaryVector:  *mat.NewVecDense(2, []float64{0, 1}),
+				Mutable:          false,
+				Link:             rules.RuleLink{},
+			},
+			edited: true,
+		},
+		{
+			name: "Complex edit test",
+			inputMatrix: rules.RuleMatrix{
+				RuleName: "Basic rule",
+				RequiredVariables: []rules.VariableFieldName{
+					rules.NumberOfBallotsCast,
+					rules.NumberOfIslandsAlive,
+				},
+				ApplicableMatrix: *mat.NewDense(2, 3, []float64{1, 1, 1, 1, 0, 1}),
+				AuxiliaryVector:  *mat.NewVecDense(2, []float64{0, 0}),
+				Mutable:          false,
+				Link:             rules.RuleLink{},
+			},
+			inputMap: medMap,
+			outputMat: rules.RuleMatrix{
+				RuleName: "Basic rule",
+				RequiredVariables: []rules.VariableFieldName{
+					rules.NumberOfBallotsCast,
+					rules.NumberOfIslandsAlive,
+				},
+				ApplicableMatrix: *mat.NewDense(2, 3, []float64{1, 1, -12, 1, 0, -5}),
+				AuxiliaryVector:  *mat.NewVecDense(2, []float64{0, 0}),
+				Mutable:          false,
+				Link:             rules.RuleLink{},
+			},
+			edited: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, succ := Shift(tc.inputMatrix, tc.inputMap)
+			if !reflect.DeepEqual(res, tc.outputMat) {
+				t.Errorf("Expected %v got %v", tc.outputMat, res)
+			}
+			if succ != tc.edited {
+				t.Errorf("Expected %v got %v", succ, tc.edited)
+			}
+		})
+	}
+}
+
 // Oh boy
 func TestFindClosestApproach(t *testing.T) {
 	cases := []struct {

--- a/internal/clients/team3/speaker.go
+++ b/internal/clients/team3/speaker.go
@@ -43,7 +43,7 @@ func (s *speaker) DecideVote(ruleMatrix rules.RuleMatrix, aliveClients []shared.
 	return shared.SpeakerReturnContent{
 		ContentType:          shared.SpeakerVote,
 		ParticipatingIslands: chosenClients,
-		RuleMatrix: 		  ruleMatrix,
+		RuleMatrix:           ruleMatrix,
 		ActionTaken:          true,
 	}
 
@@ -51,14 +51,19 @@ func (s *speaker) DecideVote(ruleMatrix rules.RuleMatrix, aliveClients []shared.
 
 func (s *speaker) DecideAnnouncement(ruleMatrix rules.RuleMatrix, result bool) shared.SpeakerReturnContent {
 	if s.c.shouldICheat() {
-		result = s.c.GetVoteForRule(ruleMatrix)
+		res := s.c.VoteForRule(ruleMatrix)
+		if res == shared.Approve {
+			result = true
+		} else {
+			result = false
+		}
 	}
 
 	return shared.SpeakerReturnContent{
-		ContentType:  	shared.SpeakerAnnouncement,
-		RuleMatrix: 	ruleMatrix,
-		VotingResult: 	result,
-		ActionTaken:  	true,
+		ContentType:  shared.SpeakerAnnouncement,
+		RuleMatrix:   ruleMatrix,
+		VotingResult: result,
+		ActionTaken:  true,
 	}
 
 }


### PR DESCRIPTION
# Summary

Shift allows our agent to intelligently propose modified rules. Essentially if we broke a rule last time, we assume we don't like it. So we propose to modify it to suit our own purposes e.g. less tax or lower sanctions.

## Test Plan

Added tests for Shift functions.
